### PR TITLE
Fix multiline message handling and Enter key submission

### DIFF
--- a/src/claude_pty_wrapper.py
+++ b/src/claude_pty_wrapper.py
@@ -37,7 +37,9 @@ def main():
     try:
         while claude_process.poll() is None:
             # Use select to handle both reading from master and stdin
-            ready, _, _ = select.select([master, sys.stdin], [], [], 0.1)
+            # Use None for blocking select (waits until data is available)
+            # This prevents busy-waiting and reduces CPU usage
+            ready, _, _ = select.select([master, sys.stdin], [], [])
             
             if master in ready:
                 try:


### PR DESCRIPTION
- Send messages in 1024-byte chunks to prevent carriage return from being included
- Remove busy-waiting in PTY wrapper by using blocking select
- Add proper wait times between chunks for PTY processing
- Ensure carriage return is sent as a separate operation

This fixes the issue where multiline messages would include the carriage return in the same chunk, causing Claude to process incomplete messages.