### PR TITLE
Fix history persistence not saving on IDE close

### DIFF
--- a/src/claude/communication/index.ts
+++ b/src/claude/communication/index.ts
@@ -3,7 +3,7 @@ import { MessageItem } from '../../core/types';
 import { messageQueue, claudeProcess, sessionReady, processingQueue, currentMessage, setCurrentMessage, setProcessingQueue } from '../../core/state';
 import { debugLog } from '../../utils/logging';
 import { updateWebviewContent, updateSessionState } from '../../ui/webview';
-import { saveWorkspaceHistory } from '../../queue/processor/history';
+import { saveWorkspaceHistory, ensureHistoryRun } from '../../queue/processor/history';
 import { TIMEOUT_MS, ANSI_CLEAR_SCREEN_PATTERNS } from '../../core/constants';
 import { startClaudeSession } from '../../claude/session';
 
@@ -337,6 +337,9 @@ function waitForPrompt(): Promise<void> {
 
 export async function startProcessingQueue(skipPermissions: boolean = true): Promise<void> {
     debugLog(`🚀 startProcessingQueue called with skipPermissions=${skipPermissions}`);
+    
+    // Start history tracking when processing begins (this is the meaningful start of a session)
+    ensureHistoryRun();
     
     if (!claudeProcess) {
         vscode.window.showInformationMessage('Starting Claude session...');


### PR DESCRIPTION
## Summary
- Fix history persistence issue where message history wasn't being saved when VS Code closes
- Improve history initialization timing to start only when meaningful work begins
- Add proper error handling for storage operations

## Root Cause
The extension was using correct storage keys (`claudeloop_*`), but history runs weren't being initialized in common usage scenarios, causing `saveWorkspaceHistory()` to return early without saving.

## Changes Made
1. **History Initialization**: Start history runs when processing begins (`startProcessingQueue()`) rather than just on extension load
2. **Improved Error Handling**: Added try-catch blocks and debug logging for storage operations  
3. **Better Timing**: History now starts at meaningful moments (processing or pending message restoration)

## Test Plan
- [x] History is created when processing starts
- [x] History survives VS Code restart
- [x] No empty history runs created unnecessarily
- [x] Error handling works for storage failures

🤖 Generated with [Claude Code](https://claude.ai/code)