### PR TITLE
feat: Add comprehensive WSL integration for Win32 command execution

### DIFF
--- a/src/claude_pty_wrapper.py
+++ b/src/claude_pty_wrapper.py
@@ -8,22 +8,11 @@ import fcntl
 import platform
 
 def get_claude_command():
-    """Get the appropriate command to run Claude CLI, with Windows PowerShell fallback."""
+    """Get the appropriate command to run Claude CLI. On Windows, always use WSL since PTY requires Unix environment."""
     if platform.system() == 'Windows':
-        # On Windows, try direct claude command first
-        try:
-            # Test if claude is directly available
-            result = subprocess.run(['claude', '--version'], 
-                                  stdout=subprocess.PIPE, 
-                                  stderr=subprocess.PIPE, 
-                                  timeout=5)
-            if result.returncode == 0:
-                return ['claude']
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            pass
-        
-        # If direct command fails, use PowerShell fallback
-        return ['powershell', '-Command', 'claude']
+        # On Windows, we must use WSL because PTY functionality requires Unix-like system calls
+        # that are not available on Windows (pty, select, fcntl modules)
+        return ['wsl', 'claude']
     else:
         # For non-Windows platforms, use direct command
         return ['claude']

--- a/src/services/git/diff.ts
+++ b/src/services/git/diff.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import { GitDiffResult, GitDiffLine, GitCompareMode } from './types';
 import { getWorkspaceRoot, resolveAndValidatePath, validateFileSize, sanitizeGitOutput, isGitRepository, GitSecurityError } from './security';
 import { GIT_TIMEOUT } from '../../core/constants/timeouts';
+import { wrapCommandForWSL } from '../../utils/wsl-helper';
 
 export async function getFileDiff(filePath: string, compareMode: GitCompareMode = 'working'): Promise<GitDiffResult> {
     const workspaceRoot = getWorkspaceRoot();
@@ -245,7 +246,8 @@ function parseDiffOutput(diffOutput: string, filePath: string): GitDiffResult {
 
 async function executeGitCommand(args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        const process = spawn('git', args, {
+        const { command, args: wrappedArgs } = wrapCommandForWSL('git', args);
+        const process = spawn(command, wrappedArgs, {
             cwd,
             stdio: ['pipe', 'pipe', 'pipe']
         });

--- a/src/services/git/expand.ts
+++ b/src/services/git/expand.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import { GitDiffLine } from './types';
 import { getWorkspaceRoot, resolveAndValidatePath, sanitizeGitOutput, isGitRepository, GitSecurityError } from './security';
 import { GIT_TIMEOUT } from '../../core/constants/timeouts';
+import { wrapCommandForWSL } from '../../utils/wsl-helper';
 
 export async function expandContext(
     filePath: string, 
@@ -100,7 +101,8 @@ export async function expandContext(
 
 async function executeGitCommand(args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        const process = spawn('git', args, {
+        const { command, args: wrappedArgs } = wrapCommandForWSL('git', args);
+        const process = spawn(command, wrappedArgs, {
             cwd,
             stdio: ['pipe', 'pipe', 'pipe']
         });

--- a/src/services/git/operations.ts
+++ b/src/services/git/operations.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import { getWorkspaceRoot, resolveAndValidatePath, sanitizeGitOutput, isGitRepository, GitSecurityError } from './security';
 import { createErrorResult } from '../../utils/error-handler';
 import { GIT_TIMEOUT } from '../../core/constants/timeouts';
+import { wrapCommandForWSL } from '../../utils/wsl-helper';
 
 export interface GitOperationResult {
     success: boolean;
@@ -257,7 +258,8 @@ export async function unstageFiles(filePaths: string[]): Promise<GitOperationRes
 
 async function executeGitCommand(args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        const process = spawn('git', args, {
+        const { command, args: wrappedArgs } = wrapCommandForWSL('git', args);
+        const process = spawn(command, wrappedArgs, {
             cwd,
             stdio: ['pipe', 'pipe', 'pipe']
         });

--- a/src/services/git/status.ts
+++ b/src/services/git/status.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { GitFileStatus, GitBranchInfo, GitStatusResult } from './types';
 import { getWorkspaceRoot, sanitizeGitOutput, isGitRepository, GitSecurityError } from './security';
 import { GIT_TIMEOUT } from '../../core/constants/timeouts';
+import { wrapCommandForWSL } from '../../utils/wsl-helper';
 
 export async function getGitStatus(): Promise<GitStatusResult> {
     const workspaceRoot = getWorkspaceRoot();
@@ -175,7 +176,8 @@ async function addDiffStats(files: GitFileStatus[], workspaceRoot: string): Prom
 
 async function executeGitCommand(args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        const process = spawn('git', args, {
+        const { command, args: wrappedArgs } = wrapCommandForWSL('git', args);
+        const process = spawn(command, wrappedArgs, {
             cwd,
             stdio: ['pipe', 'pipe', 'pipe']
         });

--- a/src/services/mobile/server/server-manager.ts
+++ b/src/services/mobile/server/server-manager.ts
@@ -7,6 +7,7 @@ import { spawn, ChildProcess } from 'child_process';
 import * as QRCode from 'qrcode';
 import { debugLog } from '../../../utils/logging';
 import { AuthManager, AuthConfig } from '../auth/';
+import { wrapCommandForWSL } from '../../../utils/wsl-helper';
 
 export class ServerManager {
     private app: express.Application;
@@ -66,7 +67,8 @@ export class ServerManager {
             
             debugLog(`🚀 Starting ngrok with args: ${ngrokArgs.join(' ')}`);
             
-            this.ngrokProcess = spawn('ngrok', ngrokArgs, {
+            const { command, args: wrappedArgs } = wrapCommandForWSL('ngrok', ngrokArgs);
+            this.ngrokProcess = spawn(command, wrappedArgs, {
                 stdio: ['ignore', 'pipe', 'pipe']
             });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 // Utilities module exports
 export * from './logging';
+export * from './wsl-helper';

--- a/src/utils/wsl-helper.ts
+++ b/src/utils/wsl-helper.ts
@@ -1,0 +1,73 @@
+/**
+ * WSL helper utilities for Windows command execution
+ * On Windows, all commands should be executed through WSL for consistency
+ */
+
+/**
+ * Wraps a command to run through WSL on Windows platforms
+ * @param command The command to execute
+ * @param args The arguments for the command
+ * @returns Object with the wrapped command and args for spawn/spawnSync
+ */
+export function wrapCommandForWSL(command: string, args: string[] = []): { command: string; args: string[] } {
+    if (process.platform === 'win32') {
+        // On Windows, run everything through WSL
+        return {
+            command: 'wsl',
+            args: [command, ...args]
+        };
+    } else {
+        // On other platforms, use the command directly
+        return {
+            command,
+            args
+        };
+    }
+}
+
+/**
+ * Converts a Windows path to WSL path format
+ * @param windowsPath The Windows path to convert
+ * @returns WSL-compatible path
+ */
+export function convertToWSLPath(windowsPath: string): string {
+    if (process.platform !== 'win32') {
+        return windowsPath;
+    }
+    
+    let wslPath = windowsPath;
+    
+    // Convert drive letter (e.g., C: -> /mnt/c, D: -> /mnt/d)
+    wslPath = wslPath.replace(/^([A-Za-z]):/, (match, driveLetter) => {
+        return `/mnt/${driveLetter.toLowerCase()}`;
+    });
+    
+    // Convert backslashes to forward slashes
+    wslPath = wslPath.replace(/\\/g, '/');
+    
+    return wslPath;
+}
+
+/**
+ * Checks if WSL is available on Windows
+ * @returns Promise<boolean> indicating WSL availability
+ */
+export async function isWSLAvailable(): Promise<boolean> {
+    if (process.platform !== 'win32') {
+        return true; // Not needed on non-Windows platforms
+    }
+    
+    const { spawnSync } = await import('child_process');
+    
+    try {
+        const { error, status } = spawnSync('wsl', ['--status'], {
+            stdio: 'pipe',
+            encoding: 'utf8',
+            timeout: 3000
+        });
+        
+        return !error && status === 0;
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
• Implements comprehensive WSL integration for all command execution on Windows
• Ensures consistent behavior across Python, Git, Claude CLI, and other tools by routing through WSL
• Adds path conversion utilities for Windows-to-WSL path mapping
• Updates dependency checkers to require and validate WSL installation on Windows

## Background
The extension uses PTY functionality that requires Unix-like system calls (pty, select, fcntl modules) which are not available on native Windows. This PR makes WSL a hard requirement on Windows and ensures all commands are properly routed through WSL for consistent execution.

## Key Changes
• **WSL Helper Utilities**: New `wsl-helper.ts` with command wrapping and path conversion functions
• **Claude Session**: Updated to use WSL for Python wrapper execution on Windows
• **Dependency Checks**: All checkers now use WSL on Windows with updated installation instructions
• **Git Operations**: All git commands routed through WSL on Windows for consistency
• **Server Management**: ngrok and other tools use WSL integration

## Test plan
- [x] Test on Windows with WSL installed - verify Claude session starts correctly
- [x] Test dependency checks show appropriate WSL requirements on Windows
- [ ] Test git operations work through WSL
- [x] Test on macOS/Linux to ensure no regression in direct command execution
- [x] Verify error messages guide users to install WSL when not available
